### PR TITLE
Correcting max_weight comment in Carrier.php

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -113,7 +113,7 @@ class CarrierCore extends ObjectModel
     /** @var int maximum package deep managed by the transporter */
     public $max_depth;
 
-    /** @var int maximum package weight managed by the transporter */
+    /** @var float maximum package weight managed by the transporter */
     public $max_weight;
 
     /** @var int grade of the shipping delay (0 for longest, 9 for shortest) */


### PR DESCRIPTION
`@var int` => `@var float`

based on :

```php
'max_weight' => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat'],
```

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.7.x
| Description?      | Correcting max_weight comment in Carrier.php 
| Type?             | comment fix
| BC breaks?        | no
| Deprecations?     | no
| Possible impacts? | None

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
